### PR TITLE
Address feedback on editions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,28 @@ val example2 =
   |""".stripMargin
 ```
 
+## Edition
+
+The `edition` setting allows Scalafmt users to stay on older default settings
+while upgrading to the latest Scalafmt release.
+
+The use-case for configuring the `edition` setting is when you want to upgrade
+to the latest Scalafmt version (for example, to enjoy a bug fix in the parser)
+but need more time to deal with the latest changes in the formatting output.
+
+The end goal for users should be to remove the `edition` setting from
+`.scalafmt.conf` in order to enjoy the latest improvements to the formatting
+output.
+
+```scala mdoc:defaults
+edition
+```
+
+The `edition` setting is formatted as `"$year-$month"` and should be interpreted
+as: "use the default settings at that given date". For example the setting
+`edition = 2019-10` means that the default settings from October 2019 should be
+used.
+
 ## Indentation
 
 ### `continuationIndent.callSite`
@@ -138,9 +160,9 @@ x match { // false for case arrows
 ```
 
 > **Pro tip**: Enable this setting to minimize git diffs/conflicts from
-> renamings and other refactorings, without having to ignore whitespace
-> changes in diffs or use `--ignore-all-space` to avoid conflicts when
-> git merging or rebasing.
+> renamings and other refactorings, without having to ignore whitespace changes
+> in diffs or use `--ignore-all-space` to avoid conflicts when git merging or
+> rebasing.
 
 #### `align=some`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -162,7 +162,7 @@ case class ScalafmtConfig(
     onTestFailure: String = "",
     encoding: Codec = "UTF-8",
     project: ProjectFiles = ProjectFiles(),
-    edition: Edition = EditionLatest
+    edition: Edition = Edition.Latest
 ) {
   private implicit val runnerReader = runner.reader
   private implicit val projectReader = project.reader
@@ -194,7 +194,7 @@ case class ScalafmtConfig(
   )
 
   val avoidEmptyLinesAroundBlock: Boolean =
-    newlines.avoidEmptyLinesAroundBlock.getOrElse(edition > Edition201910)
+    newlines.avoidEmptyLinesAroundBlock.getOrElse(edition > Edition(2019, 10))
 }
 
 object ScalafmtConfig {

--- a/scalafmt-tests/src/test/scala/org/scalafmt/EditionTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/EditionTest.scala
@@ -1,0 +1,39 @@
+package org.scalafmt
+
+import org.scalatest.FunSuite
+import org.scalafmt.util.DiffAssertions
+import org.scalafmt.config.Edition
+import metaconfig.Conf
+
+class EditionTest extends FunSuite with DiffAssertions {
+  def check(original: String, expected: Edition): Unit = {
+    test(original) {
+      val conf = Conf.Str(original)
+      val obtained = Edition.decoder.read(conf).get
+      assertNoDiff(
+        Edition.encoder.write(obtained).toString(),
+        Edition.encoder.write(expected).toString()
+      )
+    }
+  }
+  def checkError(original: String, expectedError: String): Unit = {
+    test(original) {
+      Edition.decoder.read(Conf.Str(original)).toEither match {
+        case Left(error) =>
+          assertNoDiff(error.toString(), expectedError)
+        case Right(value) =>
+          fail(s"expected error, obtained value $value")
+      }
+    }
+  }
+  check("2019-09", Edition(2019, 9))
+  check("2019-9", Edition(2019, 9))
+  check("2019-10", Edition(2019, 10))
+  checkError(
+    "2019-invalid",
+    """|Type mismatch;
+       |  found    : String (value: "2019-invalid")
+       |  expected : '$year-$month', for example '2019-08'
+       |""".stripMargin.trim
+  )
+}


### PR DESCRIPTION
* support any year-month combination instead of only 2019-10
* add documentation explaining how `edition` works